### PR TITLE
Allow far jump instructions to be replaced in trampoline if 64-bit

### DIFF
--- a/DriverShared/LocalHook/reloc.c
+++ b/DriverShared/LocalHook/reloc.c
@@ -391,8 +391,10 @@ Returns:
 				   be only 5 bytes and whereever the underlying code returns it will always
 				   be in a solid state. But this can only be guaranteed if the jump is the first
 				   instruction... */
+#ifndef _M_X64
 				if(pOld != InEntryPoint)
 					THROW(STATUS_NOT_SUPPORTED, L"Hooking far jumps is only supported if they are the first instruction.");
+#endif
 				
 				// ATTENTION: will continue in "case 0xE8"
 			}

--- a/EasyHook.nuspec
+++ b/EasyHook.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>EasyHook</id>
-        <version>2.7.6684.0</version>
+        <version>2.7.6789.0</version>
         <title>EasyHook</title>
         <authors>EasyHook</authors>
         <owners>EasyHook</owners>
@@ -13,7 +13,10 @@
 
 EasyHook currently supports injecting assemblies built for .NET Framework 3.5 and 4.0 and can also inject native DLLs.</description>
         <summary>The reinvention of Windows API Hooking</summary>
-        <releaseNotes>2.7.6684.0:
+        <releaseNotes>2.7.6789.0:
+1. Support hooking far jumps even if not first instruction for x64 (#243)
+
+2.7.6684.0:
 1. x64 trampoline: ensure stack is 16 bytes aligned (#214 and #234)
 
 2.7.6682.0:

--- a/EasyHook.nuspec
+++ b/EasyHook.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>EasyHook</id>
-        <version>2.7.6682.0</version>
+        <version>2.7.6684.0</version>
         <title>EasyHook</title>
         <authors>EasyHook</authors>
         <owners>EasyHook</owners>
@@ -13,7 +13,10 @@
 
 EasyHook currently supports injecting assemblies built for .NET Framework 3.5 and 4.0 and can also inject native DLLs.</description>
         <summary>The reinvention of Windows API Hooking</summary>
-        <releaseNotes>2.7.6682.0:
+        <releaseNotes>2.7.6684.0:
+1. x64 trampoline: ensure stack is 16 bytes aligned (#214 and #234)
+
+2.7.6682.0:
 1. Quoted service path to avoid path spaces vulnerability (outlined in CVE-2005-1185, CVE-2005-2938 and CVE-2000-1128)
 2. Rename CLIENT_ID struct to DBG_CLIENT_ID (fix build error on Windows SDK 10.0.16299.0) (#225)
 3. NuGet support for VS2017 (v141) native C/C++ package (#181)

--- a/EasyHookNative.autopkg
+++ b/EasyHookNative.autopkg
@@ -10,7 +10,7 @@
 nuget {
    nuspec {
       id = EasyHookNativePackage;
-      version : 2.7.6682.0;
+      version : 2.7.6684.0;
       title: EasyHook Native Package;
       authors: {EasyHook};
       owners: {EasyHook};
@@ -20,7 +20,10 @@ nuget {
       summary:The reinvention of Windows API Hooking;
       description: @"This project supports extending (hooking) unmanaged code (APIs) on 32- or 64-bit
 Windows XP SP2, Windows Vista x64, Windows Server 2008 x64, Windows 7, Windows 8.1, and Windows 10.";
-      releaseNotes: @"2.7.6682.0:
+      releaseNotes: @"2.7.6684.0:
+1. x64 trampoline: ensure stack is 16 bytes aligned (#214 and #234)
+
+2.7.6682.0:
 1. Quoted service path to avoid path spaces vulnerability (outlined in CVE-2005-1185, CVE-2005-2938 and CVE-2000-1128)
 2. Rename CLIENT_ID struct to DBG_CLIENT_ID (fix build error on Windows SDK 10.0.16299.0) (#225)
 3. NuGet support for VS2017 (v141) native C/C++ package (#181)

--- a/EasyHookNative.autopkg
+++ b/EasyHookNative.autopkg
@@ -10,7 +10,7 @@
 nuget {
    nuspec {
       id = EasyHookNativePackage;
-      version : 2.7.6684.0;
+      version : 2.7.6789.0;
       title: EasyHook Native Package;
       authors: {EasyHook};
       owners: {EasyHook};
@@ -20,7 +20,10 @@ nuget {
       summary:The reinvention of Windows API Hooking;
       description: @"This project supports extending (hooking) unmanaged code (APIs) on 32- or 64-bit
 Windows XP SP2, Windows Vista x64, Windows Server 2008 x64, Windows 7, Windows 8.1, and Windows 10.";
-      releaseNotes: @"2.7.6684.0:
+      releaseNotes: @"2.7.6789.0:
+1. Support hooking far jumps even if not first instruction for x64 (#243)
+
+2.7.6684.0:
 1. x64 trampoline: ensure stack is 16 bytes aligned (#214 and #234)
 
 2.7.6682.0:


### PR DESCRIPTION
Fixes #243