### PR TITLE
Restore readonly flag upon hook uninstall

### DIFF
--- a/DriverShared/LocalHook/uninstall.c
+++ b/DriverShared/LocalHook/uninstall.c
@@ -202,12 +202,17 @@ Descriptions:
 #ifdef X64_DRIVER
             CurrentIRQL = KeGetCurrentIrql();
             RtlWPOff();
+#else
+            RtlProtectMemory(Hook->TargetProc, Hook->EntrySize, PAGE_EXECUTE_READWRITE);
 #endif
+
             *((ULONGLONG*)Hook->TargetProc) = Hook->TargetBackup;
 #ifdef X64_DRIVER
             // we support a trampoline jump of up to 16 bytes in X64_DRIVER
             *((ULONGLONG*)(Hook->TargetProc + 8)) = Hook->TargetBackup_x64;
             RtlWPOn(CurrentIRQL);
+#else
+            RtlProtectMemory(Hook->TargetProc, Hook->EntrySize, PAGE_EXECUTE_READ);
 #endif
 
 #pragma warning(disable: 4127)

--- a/appveyor.driver.yml
+++ b/appveyor.driver.yml
@@ -11,13 +11,13 @@ image:
 
 configuration:
   - Win10-Release
-  - Win10-Debug
+#  - Win10-Debug
   - Win8.1-Release
-  - Win8.1-Debug
+#  - Win8.1-Debug
   - Win8-Release
-  - Win8-Debug
+#  - Win8-Debug
   - Win7-Release
-  - Win7-Debug
+#  - Win7-Debug
 
 platform:
   - Win32

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,9 +13,9 @@ image:
 
 configuration:
   - netfx4-Release
-  - netfx4-Debug
+#  - netfx4-Debug
   - netfx3.5-Release
-  - netfx3.5-Debug
+#  - netfx3.5-Debug
 
 platform:
   - x64


### PR DESCRIPTION
Restore the readonly flag upon hook uninstall (closes #183)

Due to the internals of EasyHook it isn't possible to completely remove the writable flag during the lifetime of the hook, but we now restore the memory protection upon hook uninstall.