### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/build_me.txt
+++ b/build_me.txt
@@ -32,3 +32,17 @@ Containing the following files:
 .\Deploy\NetFX3.5\*
 .\Deploy\NetFX4.0\*
 .\Deploy\Source\*
+
+*******************************************************************************
+* Installing and building easyhook via vcpkg
+*******************************************************************************
+
+You can download and install easyhook using the vcpkg(https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    vcpkg install easyhook
+
+The easyhook port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please create an issue or pull request(https://github.com/Microsoft/vcpkg) on the vcpkg repository.


### PR DESCRIPTION
`easyhook `is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for easyhook and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build easyhook, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (Windows: x86, x64) to keep a wide coverage for users.
Note: Currently this port only supports dynamic build.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/easyhook/portfile.cmake). We try to keep the library maintained as close as possible to the original library.