### PR TITLE
Bugfix to prevent heap corruption

### DIFF
--- a/DriverShared/LocalHook/alloc.c
+++ b/DriverShared/LocalHook/alloc.c
@@ -40,7 +40,7 @@ Parameters:
         by this method!
 */
 
-#if defined(_M_X64) && !defined(DRIVER)
+#if !defined(DRIVER)
     VirtualFree(*RefHandle, 0, MEM_RELEASE);
 #else
     RtlFreeMemory(*RefHandle);
@@ -108,7 +108,7 @@ Returns:
 
     UCHAR*			    Res = NULL;
 
-#if defined(_M_X64) && !defined(DRIVER)
+#if !defined(DRIVER)
     LONGLONG            Base;
     LONGLONG		    iStart;
     LONGLONG		    iEnd;
@@ -128,7 +128,7 @@ Returns:
 
 
     // reserve page with execution privileges
-#if defined(_M_X64) && !defined(DRIVER)
+#if !defined(DRIVER)
 
     /*
         Reserve memory around entry point...
@@ -166,10 +166,10 @@ Returns:
 
     if(Res == NULL)
 	    return NULL;
-#else
-    
+
+#else 
+
 	*OutPageSize = PAGE_SIZE;
-	// in 32-bit mode the trampoline will always be reachable
 	// In 64-bit driver mode we use an absolute address so the trampoline will always be reachable
     if((Res = (UCHAR*)RtlAllocateMemory(TRUE, PAGE_SIZE)) == NULL)
         return NULL;


### PR DESCRIPTION
Depending on the memory management of the operating system it was possible that in a 32 bit process a relative jump was created to an not accessible address. The reason for the bug is that the possible address range is larger than the one reachable for the relative jump. This bug is fixed with this PR. 