### PR TITLE
Fix disassemble length check

### DIFF
--- a/DriverShared/LocalHook/reloc.c
+++ b/DriverShared/LocalHook/reloc.c
@@ -137,7 +137,7 @@ Returns:
     
     *nextInstr = (ULONG64)InPtr + *length;
 
-    if(length > 0)
+    if(*length > 0)
         return STATUS_SUCCESS;
     else
         return STATUS_INVALID_PARAMETER;

--- a/EasyHookDll/RemoteHook/thread.c
+++ b/EasyHookDll/RemoteHook/thread.c
@@ -1382,7 +1382,7 @@ Returns:
 		}
 	}
 	else if(Code != WAIT_OBJECT_0 + 1)
-		THROW(STATUS_INTERNAL_ERROR, L"Unable to wait for injection completion due to timeout. ");
+		THROW(STATUS_INTERNAL_ERROR, L"Unable to wait for injection completion due to timeout.");
 
     RETURN;
 


### PR DESCRIPTION
Was checking a pointer instead of the pointer value.

And removing extra space in an error string.