### PR TITLE
Fix the problem that sometime EasyHook will throw a STATUS_INTERNAL_ERROR with error code 5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ obj/
 [Rr]elease*/
 _ReSharper*/
 [Tt]est[Rr]esult*
+.vs
+packages

--- a/DriverShared/Rtl/error.c
+++ b/DriverShared/Rtl/error.c
@@ -96,10 +96,10 @@ void RtlSetLastError(LONG InCode, NTSTATUS InNtStatus, WCHAR* InMessage)
         if (lstrlenW(InMessage) > 0)
         {
             WCHAR msg[1024] = { 0 };
-            LPVOID lpMsgBuf;
 
             if (InNtStatus == STATUS_SUCCESS) 
             {
+                LPVOID lpMsgBuf;
                 FormatMessage(
                     FORMAT_MESSAGE_ALLOCATE_BUFFER | 
                     FORMAT_MESSAGE_FROM_SYSTEM |
@@ -110,14 +110,13 @@ void RtlSetLastError(LONG InCode, NTSTATUS InNtStatus, WCHAR* InMessage)
                     (LPTSTR) &lpMsgBuf,
                     0, NULL );
                 _snwprintf_s(msg, 1024, _TRUNCATE, L"%s (%s)\n", InMessage, lpMsgBuf);
+                LocalFree(lpMsgBuf);
             }
             else 
             {
                 _snwprintf_s(msg, 1024, _TRUNCATE, L"%s (%s)\n", InMessage, RtlErrorCodeToString(InNtStatus));
             }
             DEBUGMSG(msg);
-
-            LocalFree(lpMsgBuf);
         }
 #endif
         LastError = (PWCHAR)InMessage;


### PR DESCRIPTION
The `GetRemoteFuncAddress` function calls `GetRemoteModuleHandle` function which calls the `CreateToolhelp32Snapshot` WinAPI. According to [Microsoft's documentation](https://learn.microsoft.com/en-us/windows/win32/api/tlhelp32/nf-tlhelp32-createtoolhelp32snapshot):
> If the function fails with ERROR_BAD_LENGTH when called with TH32CS_SNAPMODULE or TH32CS_SNAPMODULE32, call the function again until it succeeds.

So, the current usage of this API is wrong:
https://github.com/EasyHook/EasyHook/blob/16f641c8e2197b01095f548c94dcbe696a816a05/EasyHookDll/RemoteHook/thread.c#L811-L815
This API can return `INVALID_HANDLE_VALUE` for no reason, especially in a suspended process, resulting to `NULL` value of the function pointers in the `REMOTE_INFO` struct. When the `Injection_ASM_x64` or `Injection_ASM_x32` routine calls into the NULL-valued function pointers, the remote thread will end with the result value 0xC0000005 (Access Violation). EasyHook clips out the higher bits then report 5 to the user.

This API can be used like this:
```cpp
HANDLE tlh;
for (int retryTime = 0; retryTime < 5; retryTime++)
{
    tlh = CreateToolhelp32Snapshot(TH32CS_SNAPMODULE, pId);
    if (tlh != INVALID_HANDLE_VALUE || GetLastError() != ERROR_BAD_LENGTH)
        break;
}
if (tlh == INVALID_HANDLE_VALUE)
    return NULL;
```
On my computer, if this API fails, it will works from the 2nd calls.

Also, the below `LocalFree` should be right after the `FormatMessage` call, if another branch is taken, then `lpMsgBuf` is uninitialized:
https://github.com/EasyHook/EasyHook/blob/16f641c8e2197b01095f548c94dcbe696a816a05/DriverShared/Rtl/error.c#L120