### PR TITLE
MinGW-W64 compatibility

### DIFF
--- a/Public/easyhook.h
+++ b/Public/easyhook.h
@@ -35,9 +35,12 @@
 	typedef void* HMODULE;
 
 #else
-
-    #define NTDDI_VERSION           NTDDI_WIN2KSP4
-    #define _WIN32_WINNT            0x500
+    #ifndef NTDDI_VERSION
+        #define NTDDI_VERSION           NTDDI_WIN2KSP4
+    #endif
+    #ifndef _WIN32_WINNT
+        #define _WIN32_WINNT            0x500
+    #endif
     #define _WIN32_IE_              _WIN32_IE_WIN2KSP4
 
     #include <windows.h>


### PR DESCRIPTION
avoid
```
g++ -O0 -Wall -Wextra -Wpedantic -Werror -Wno-unused-function EasyHook64.dll speed.cpp In file included from speed.cpp:14:
easyhook.h:39:13: error: "NTDDI_VERSION" redefined [-Werror]
   39 |     #define NTDDI_VERSION           NTDDI_WIN2KSP4
      |             ^~~~~~~~~~~~~
In file included from C:/MinGW/mingw64/x86_64-w64-mingw32/include/windows.h:10,
                 from speed.cpp:2:
C:/MinGW/mingw64/x86_64-w64-mingw32/include/sdkddkver.h:174:9: note: this is the location of the previous definition
  174 | #define NTDDI_VERSION NTDDI_VERSION_FROM_WIN32_WINNT(_WIN32_WINNT)
      |         ^~~~~~~~~~~~~
easyhook.h:40:13: error: "_WIN32_WINNT" redefined [-Werror]
   40 |     #define _WIN32_WINNT            0x500
      |             ^~~~~~~~~~~~
In file included from C:/MinGW/mingw64/x86_64-w64-mingw32/include/corecrt.h:10,
                 from C:/MinGW/mingw64/x86_64-w64-mingw32/include/wchar.h:9,
                 from C:/MinGW/mingw64/lib/gcc/x86_64-w64-mingw32/14.2.0/include/c++/cwchar:44,
                 from C:/MinGW/mingw64/lib/gcc/x86_64-w64-mingw32/14.2.0/include/c++/bits/postypes.h:40,
                 from C:/MinGW/mingw64/lib/gcc/x86_64-w64-mingw32/14.2.0/include/c++/iosfwd:42,
                 from C:/MinGW/mingw64/lib/gcc/x86_64-w64-mingw32/14.2.0/include/c++/ios:40,
                 from C:/MinGW/mingw64/lib/gcc/x86_64-w64-mingw32/14.2.0/include/c++/ostream:40,
                 from C:/MinGW/mingw64/lib/gcc/x86_64-w64-mingw32/14.2.0/include/c++/iostream:41,
                 from speed.cpp:1:
C:/MinGW/mingw64/x86_64-w64-mingw32/include/_mingw.h:232:9: note: this is the location of the previous definition
  232 | #define _WIN32_WINNT 0xa00
      |         ^~~~~~~~~~~~
cc1plus.exe: all warnings being treated as errors
```